### PR TITLE
Added some more Red Gate tools, and updated some Platform tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,6 +217,12 @@ perks:
   
 - perk: {name: SQL Test, uri: 'http://www.red-gate.com/products/sql-development/sql-test/'} 
   description: A tool to quickly set up unit testing for databases in SQL Server Management Studio without a complex initial process, to make CI and Agile database development easier to achieve.
+  categories: [IDE, Productivity, SQL, Database, Testing]
+  platforms: [Any]
+  company: *redgate
+  
+- perk: {name: SQL Dependency Tracker, uri: 'http://www.red-gate.com/products/sql-development/sql-dependency-tracker/'} 
+  description: Allows you to dynamically explore and document  database object dependencies using several graphical layouts - integrates directly with SSMS.
   categories: [IDE, Productivity, SQL, Database]
   platforms: [Any]
   company: *redgate

--- a/index.html
+++ b/index.html
@@ -223,7 +223,13 @@ perks:
   
 - perk: {name: SQL Dependency Tracker, uri: 'http://www.red-gate.com/products/sql-development/sql-dependency-tracker/'} 
   description: Allows you to dynamically explore and document  database object dependencies using several graphical layouts - integrates directly with SSMS.
-  categories: [IDE, Productivity, SQL, Database]
+  categories: [IDE, Productivity, SQL, Database, Visualization]
+  platforms: [Any]
+  company: *redgate
+  
+- perk: {name: SQL Data Generator, uri: 'http://www.red-gate.com/products/sql-development/sql-data-generator/'} 
+  description: A fast, simple tool for generating test data using existing table and column names, field length, data types and other existing constraints to provide sensible generators. The generators can be customized to meet your requirements, and include a scriptable Python generator.
+  categories: [IDE, Productivity, SQL, Database, Testing]
   platforms: [Any]
   company: *redgate
 

--- a/index.html
+++ b/index.html
@@ -214,6 +214,12 @@ perks:
   categories: [Translation, Localization]
   platforms: [Any]
   company: {name: Get Localization, uri: 'http://www.getlocalization.com/'}
+  
+- perk: {name: SQL Test, uri: 'http://www.red-gate.com/products/sql-development/sql-test/'} 
+  description: A tool to quickly set up unit testing for databases in SQL Server Management Studio without a complex initial process, to make CI and Agile database development easier to achieve.
+  categories: [IDE, Productivity, SQL, Database]
+  platforms: [Any]
+  company: *redgate
 
 #============================================== Leave everything below this line alone =====================================================================
 layout: default

--- a/index.html
+++ b/index.html
@@ -197,6 +197,12 @@ perks:
   platforms: [Any]
   company: *redgate
 
+- perk: {name: MySQL Data Compare, uri: 'http://reflectorblog.red-gate.com/2013/07/open-source/'} 
+  description: Compare and synchronize the data of MySQL databases
+  categories: [IDE, Productivity, MySQL, Database]
+  platforms: [Any]
+  company: *redgate
+
 - perk: {name: Deployment Suite for Oracle, uri: 'http://reflectorblog.red-gate.com/2013/07/open-source/'} 
   description: Compare, deploy and source-control Oracle databases
   categories: [IDE, Productivity, Oracle, Database]

--- a/index.html
+++ b/index.html
@@ -188,13 +188,13 @@ perks:
 - perk: {name: SQL Prompt, uri: 'http://reflectorblog.red-gate.com/2013/07/open-source/'} 
   description: Whether you need to write, edit, or explore database code, SQL Prompt makes things effortless.
   categories: [IDE, Productivity, SQL Server, Database]
-  platforms: [Any]
+  platforms: [SQL]
   company: *redgate
 
 - perk: {name: MySQL Compare, uri: 'http://reflectorblog.red-gate.com/2013/07/open-source/'} 
   description: Compare and synchronize the schemas of MySQL databases
   categories: [IDE, Productivity, MySQL, Database]
-  platforms: [Any]
+  platforms: [MySQL]
   company: *redgate
 
 - perk: {name: SQL Doc, uri: 'http://www.red-gate.com/products/sql-development/sql-doc/'} 
@@ -206,7 +206,7 @@ perks:
 - perk: {name: Deployment Suite for Oracle, uri: 'http://reflectorblog.red-gate.com/2013/07/open-source/'} 
   description: Compare, deploy and source-control Oracle databases
   categories: [IDE, Productivity, Oracle, Database]
-  platforms: [Any]
+  platforms: [Oracle]
   company: *redgate
   
 - perk: {name: Get Localization, uri: 'http://www.getlocalization.com/signup/'} 
@@ -218,19 +218,19 @@ perks:
 - perk: {name: SQL Test, uri: 'http://www.red-gate.com/products/sql-development/sql-test/'} 
   description: A tool to quickly set up unit testing for databases in SQL Server Management Studio without a complex initial process, to make CI and Agile database development easier to achieve.
   categories: [IDE, Productivity, SQL, Database, Testing]
-  platforms: [Any]
+  platforms: [Test]
   company: *redgate
   
 - perk: {name: SQL Dependency Tracker, uri: 'http://www.red-gate.com/products/sql-development/sql-dependency-tracker/'} 
   description: Allows you to dynamically explore and document  database object dependencies using several graphical layouts - integrates directly with SSMS.
   categories: [IDE, Productivity, SQL, Database, Visualization]
-  platforms: [Any]
+  platforms: [SQL]
   company: *redgate
   
 - perk: {name: SQL Data Generator, uri: 'http://www.red-gate.com/products/sql-development/sql-data-generator/'} 
   description: A fast, simple tool for generating test data using existing table and column names, field length, data types and other existing constraints to provide sensible generators. The generators can be customized to meet your requirements, and include a scriptable Python generator.
   categories: [IDE, Productivity, SQL, Database, Testing]
-  platforms: [Any]
+  platforms: [SQL]
   company: *redgate
 
 #============================================== Leave everything below this line alone =====================================================================

--- a/index.html
+++ b/index.html
@@ -197,10 +197,10 @@ perks:
   platforms: [Any]
   company: *redgate
 
-- perk: {name: MySQL Data Compare, uri: 'http://reflectorblog.red-gate.com/2013/07/open-source/'} 
-  description: Compare and synchronize the data of MySQL databases
-  categories: [IDE, Productivity, MySQL, Database]
-  platforms: [Any]
+- perk: {name: SQL Doc, uri: 'http://www.red-gate.com/products/sql-development/sql-doc/'} 
+  description: A fast, simple tool which automatically generates database documentation. Create documents in HTML, Microsoft Word or Compiled HTML Help files. Information about object definitions and dependencies is automatically included, and you can add further descriptions to your database objects if necessary.
+  categories: [IDE, Productivity, SQL, Database, Documentation]
+  platforms: [SQL]
   company: *redgate
 
 - perk: {name: Deployment Suite for Oracle, uri: 'http://reflectorblog.red-gate.com/2013/07/open-source/'} 

--- a/index.html
+++ b/index.html
@@ -197,7 +197,7 @@ perks:
   platforms: [MySQL]
   company: *redgate
 
-- perk: {name: SQL Doc, uri: 'http://www.red-gate.com/products/sql-development/sql-doc/'} 
+- perk: {name: SQL Doc, uri: 'https://www.simple-talk.com/blogs/2013/09/25/sql-support-for-oss-projects/'} 
   description: A fast, simple tool which automatically generates database documentation. Create documents in HTML, Microsoft Word or Compiled HTML Help files. Information about object definitions and dependencies is automatically included, and you can add further descriptions to your database objects if necessary.
   categories: [IDE, Productivity, SQL, Database, Documentation]
   platforms: [SQL]
@@ -215,19 +215,19 @@ perks:
   platforms: [Any]
   company: {name: Get Localization, uri: 'http://www.getlocalization.com/'}
   
-- perk: {name: SQL Test, uri: 'http://www.red-gate.com/products/sql-development/sql-test/'} 
+- perk: {name: SQL Test, uri: 'https://www.simple-talk.com/blogs/2013/09/25/sql-support-for-oss-projects/'} 
   description: A tool to quickly set up unit testing for databases in SQL Server Management Studio without a complex initial process, to make CI and Agile database development easier to achieve.
   categories: [IDE, Productivity, SQL, Database, Testing]
   platforms: [Test]
   company: *redgate
   
-- perk: {name: SQL Dependency Tracker, uri: 'http://www.red-gate.com/products/sql-development/sql-dependency-tracker/'} 
+- perk: {name: SQL Dependency Tracker, uri: 'https://www.simple-talk.com/blogs/2013/09/25/sql-support-for-oss-projects/'} 
   description: Allows you to dynamically explore and document  database object dependencies using several graphical layouts - integrates directly with SSMS.
   categories: [IDE, Productivity, SQL, Database, Visualization]
   platforms: [SQL]
   company: *redgate
   
-- perk: {name: SQL Data Generator, uri: 'http://www.red-gate.com/products/sql-development/sql-data-generator/'} 
+- perk: {name: SQL Data Generator, uri: 'https://www.simple-talk.com/blogs/2013/09/25/sql-support-for-oss-projects/'} 
   description: A fast, simple tool for generating test data using existing table and column names, field length, data types and other existing constraints to provide sensible generators. The generators can be customized to meet your requirements, and include a scriptable Python generator.
   categories: [IDE, Productivity, SQL, Database, Testing]
   platforms: [SQL]


### PR DESCRIPTION
A few of the new tools don't have "official" blog posts associated with them to announce that they're free to OSS, but they're internally in that bucket (and the sales teams know that). Do we need to puts some clear public information anywhere?
