### PR TITLE
Adding ALT attribute to IMG tags and changing closing tag from "PIV" to "P"

### DIFF
--- a/_includes/perk.html
+++ b/_includes/perk.html
@@ -9,5 +9,5 @@
 	{% for category in item.categories %}<span class="tag category">{{ category }}</span>{% endfor %}
 	</span>
 	
-	<p>{{ item.description }}</piv>
+	<p>{{ item.description }}</p>
 </li>

--- a/_includes/perk.html
+++ b/_includes/perk.html
@@ -1,6 +1,6 @@
 <li>
 	<h2>
-		<img class="company-logo" src="//plus.google.com/_/favicon?domain={{ item.company.uri }}"/>
+		<img class="company-logo" src="//plus.google.com/_/favicon?domain={{ item.company.uri }}" alt="{{ item.company.name }}"/>
 		<a href="{{ item.perk.uri }}">{{ item.perk.name }}</a>
 	</h2>
 	<small>by <a href="{{ item.company.uri }}">{{ item.company.name }}</a></small>


### PR DESCRIPTION
1. An IMG element must have an ALT attribute. This commit is to add ALT attribute to IMG tags.
2. Fixing a small typo: changing closing tag from "PIV" to "P".
